### PR TITLE
Update exceptions dependency

### DIFF
--- a/tagged-transformer.cabal
+++ b/tagged-transformer.cabal
@@ -31,7 +31,7 @@ library
     comonad                   >= 4        && < 5,
     contravariant             >= 0.3      && < 1,
     distributive              >= 0.3      && < 1,
-    exceptions                >= 0.1.1    && < 1,
+    exceptions                >= 0.2      && < 1,
     mtl                       >= 2.0.1    && < 2.2,
     reflection                >= 1.1.6    && < 2,
     semigroupoids             >= 4        && < 5,


### PR DESCRIPTION
`tagged-transformer` isn't compatible with `exceptions-0.1.1`:

```
[1 of 1] Compiling Data.Functor.Trans.Tagged ( src/Data/Functor/Trans/Tagged.hs, dist/build/Data/Functor/Trans/Tagged.o )

src/Data/Functor/Trans/Tagged.hs:231:3:
    `uninterruptibleMask' is not a (visible) method of class `MonadCatch'

src/Data/Functor/Trans/Tagged.hs:231:33:
    Not in scope: `uninterruptibleMask'

src/Data/Functor/Trans/Tagged.hs:233:14:
    `uninterruptibleMask' is not a (visible) method of class `MonadCatch'
```
