### PR TITLE
Support exceptions-0.9.0

### DIFF
--- a/src/Data/Functor/Trans/Tagged.hs
+++ b/src/Data/Functor/Trans/Tagged.hs
@@ -324,6 +324,14 @@ instance MonadMask m => MonadMask (TaggedT s m) where
   uninterruptibleMask a = TagT $ uninterruptibleMask $ \u -> untagT (a $ q u)
     where q u = TagT . u . untagT
   {-# INLINE uninterruptibleMask#-}
+#if MIN_VERSION_exceptions(0,9,0)
+  generalBracket acquire release cleanup use = TagT $
+    generalBracket
+      (untagT acquire)
+      (untagT . release)
+      (\resource e -> untagT (cleanup resource e))
+      (\resource -> untagT (use resource))
+#endif
 
 -- | Easier to type alias for 'TagT'
 tagT :: m b -> TaggedT s m b


### PR DESCRIPTION
`exceptions-0.9.0` added a `generalBracket` method to `MonadMask`. This PR implements it for the `MonadMask` instance for `TaggedT`.